### PR TITLE
git-unmerged branch exclusion

### DIFF
--- a/lib/git-unmerged.rb
+++ b/lib/git-unmerged.rb
@@ -136,6 +136,7 @@ class GitUnmerged
       |  -a   display all unmerged commits (verbose)
       |  --remote   compare remote branches instead of local branches
       |  --upstream <branch>   specify a specific upstream branch
+      |  --exclude <branch>[,<branch>,...]   specify a comma-separated list of branches to exclude
       | 
       |EXAMPLE: check for all unmerged commits
       |  #{$0}


### PR DESCRIPTION
added ability to exclude branches from git-unmerged by passing --exclude with a comma-separated list of branch names
