### PR TITLE
Adding 'git open-pull' alias.

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -70,6 +70,9 @@
 
   # +open-url+ opens the home page for this repository
   open-url = !"open `git remote show origin | grep 'Fetch URL' | ruby -e \"puts 'http://' + STDIN.read.scan(/Fetch URL: git@(.*)/).join.sub(':', '/').sub('.git','')\"`"
+
+  # e.g. - https://github.com/account/repos/pull/new/chore/branch-name-here
+  open-pull = !"open `git remote show origin | grep 'Fetch URL' | ruby -e \"puts 'http://' + STDIN.read.scan(/Fetch URL: git@(.*)/).join.sub(':', '/').sub('.git','') + \\\\\"/pull/new/#{%x|git cbranch|}\\\\\"\"`"
   
 [push]
   # default to tracking so git will only try to push the current branch


### PR DESCRIPTION
This makes it possible to run `git open-pull` to open a new pull request page with your system's default browser.

Be sure to run `~/.tidbits/bin/tidbits_update_gitconfig` after pulling. This will put it in your ~/.gitconfig safely.
